### PR TITLE
Build script fix for vs2019

### DIFF
--- a/vs_path.bat
+++ b/vs_path.bat
@@ -13,8 +13,12 @@ if not exist %VsWhere% goto :eof
 
 set vs_ver=""
 
-for /f "usebackq tokens=1* delims=: " %%i in (`%VsWhere% -latest -requires Microsoft.VisualStudio.Component.VC.140`) do (
+%VsWhere% -version [14.0,16.0) -latest -requires Microsoft.VisualStudio.Component.VC.140 >temp_maya_inst_studios
+
+for /f "usebackq tokens=1* delims=: " %%i in (temp_maya_inst_studios) do (
 	if /i "%%i"=="installationVersion" set vs_ver=%%j
 
 	if /i "%%i"=="installationPath" set vs_dir=%%j
 )
+
+del temp_maya_inst_studios


### PR DESCRIPTION
CIS guys asked to make a fix for Max plugin for VS2019

PURPOSE
If VS2019 is installed on CIS build script fails.

EFFECT OF CHANGES:
VS2019 existance on a machine does not break building process.